### PR TITLE
Remove `before_install` step

### DIFF
--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -1,8 +1,3 @@
 language: ruby
 
 cache: bundler
-
-before_install:
-  # "yes" is a workaround for https://github.com/rubygems/rubygems/issues/3030
-  - yes | travis_retry gem update --system
-  - travis_retry gem install bundler -v "<2"


### PR DESCRIPTION
We are running all apps on Bundler 2 now so there should be no need to install latest 1.x version of Bundler anymore.

Also, let's stop updating RubyGems. I think it's better that we run the same version on Travis CI as in our DC (and so on).

These changes combined should save us a few seconds.

Close #1